### PR TITLE
enumの取得方法を改善

### DIFF
--- a/c2aenum/enum_loader.py
+++ b/c2aenum/enum_loader.py
@@ -53,17 +53,24 @@ class C2aEnum:
 
     def _load_numbered_enum_from_file(self, path, prefix):
         path = self.path + path
-        p = re.compile(r"^  ({}\w+) = (\w+)".format(prefix))
+        p_with_id = re.compile(r"^  ({}\w+) = (\w+)".format(prefix))
+        p_without_id = re.compile(r"^  ({}\w+)".format(prefix))
 
         with open(path, encoding="shift_jis") as f:
 
+            last_enum_id = 0
             for line in f.readlines():
-                m = p.match(line)
-                if not m:
+                m_with_id = p_with_id.match(line)
+                m_without_id = p_without_id.match(line)
+                if not m_with_id and not m_without_id:
                     continue
 
-                enum_name = m.group(1)
-                enum_id   = m.group(2)
+                if m_with_id:
+                    enum_name = m_with_id.group(1)
+                    enum_id   = m_with_id.group(2)
+                else:
+                    enum_name = m_without_id.group(1)
+                    enum_id   = str(last_enum_id + 1)
 
                 if enum_id[:2] == "0x":
                     enum_id = int(enum_id, base=16)
@@ -71,6 +78,7 @@ class C2aEnum:
                     enum_id = int(enum_id, base=10)
 
                 self.__setattr__(enum_name, enum_id)
+                last_enum_id = enum_id
 
     def _load_non_numbered_enum_from_file(self, path, prefix):
         # TBD

--- a/c2aenum/enum_loader.py
+++ b/c2aenum/enum_loader.py
@@ -53,7 +53,7 @@ class C2aEnum:
 
     def _load_numbered_enum_from_file(self, path, prefix):
         path = self.path + path
-        p = re.compile("^  ({}\w+) = (\w+)".format(prefix))
+        p = re.compile(r"^  ({}\w+) = (\w+)".format(prefix))
 
         with open(path, encoding="shift_jis") as f:
 

--- a/c2aenum/enum_loader.py
+++ b/c2aenum/enum_loader.py
@@ -58,7 +58,7 @@ class C2aEnum:
 
         with open(path, encoding="shift_jis") as f:
 
-            last_enum_id = 0
+            last_enum_id = -1
             for line in f.readlines():
                 m_with_id = p_with_id.match(line)
                 m_without_id = p_without_id.match(line)

--- a/c2aenum/enum_loader.py
+++ b/c2aenum/enum_loader.py
@@ -53,7 +53,7 @@ class C2aEnum:
 
     def _load_numbered_enum_from_file(self, path, prefix):
         path = self.path + path
-        p_with_id = re.compile(r"^  ({}\w+) = (\w+)".format(prefix))
+        p_with_id = re.compile(r"^  ({}\w+) += +(\w+)".format(prefix))
         p_without_id = re.compile(r"^  ({}\w+)".format(prefix))
 
         with open(path, encoding="shift_jis") as f:

--- a/c2aenum/enum_loader.py
+++ b/c2aenum/enum_loader.py
@@ -53,7 +53,7 @@ class C2aEnum:
 
     def _load_numbered_enum_from_file(self, path, prefix):
         path = self.path + path
-        p = re.compile("  {}.* = .*,.*".format(prefix))
+        p = re.compile("^  ({}\w+) = (\w+)".format(prefix))
 
         with open(path, encoding="shift_jis") as f:
 
@@ -62,9 +62,8 @@ class C2aEnum:
                 if not m:
                     continue
 
-                # 最初の空白と後ろのカンマ・改行を捨てる
-                enum_name, enum_id = m.string[2:-2].split(" = ")
-                enum_id = enum_id.split(",")[0]
+                enum_name = m.group(1)
+                enum_id   = m.group(2)
 
                 if enum_id[:2] == "0x":
                     enum_id = int(enum_id, base=16)


### PR DESCRIPTION
## 概要
enumの取得方法を改善

## Issue
- https://github.com/ut-issl/c2a-enum-loader/issues/2

## 詳細
- enumの最後の列挙子である _MAX なども取得できるように正規表現を改善
- 数字の書いてないenumも取得できるように
- 正規表現を適切な方法へ

## 検証結果
https://github.com/ut-issl/c2a-core/tree/94e228155c9f964cf3a5199c5b010f0371c48cd2/Examples/minimum_user_for_s2e/src/src_user/Test をざっと回してOKそうだった
